### PR TITLE
Enhanced README.md by adding the more sections for helping the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,28 @@
 
 ___
 
-This is a an effort to try and use Qt5 the c++ gui toolkit. The notepad app is about *50KB* in size and is a standalone [executable](https://github.com/rattle99/QtNotepad/releases) with basic functionalities such as opening, saving, printing and creating new files.
+QtNotepad is about *50KB* in size and is a standalone [executable](https://github.com/rattle99/QtNotepad/releases) with basic functionalities such as opening, saving, printing and creating new files.
+
+## Installation
+
+*** Text ***
+
+## Usage
+
+*** Text ***
+
+## Contributions
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+## License
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to http://unlicense.org


### PR DESCRIPTION
Added "How to install" and "How to use" sections in README.md to help the user by saving their time in figuring out how to install and use the app. I really don't know much about the app so you can add text under those sections. Also, the license part could be included in the README.md
Fixes #3 